### PR TITLE
feat: add `chai-expect-to-node-assert`

### DIFF
--- a/codemods/chai-expect-to-node-assert.yml
+++ b/codemods/chai-expect-to-node-assert.yml
@@ -1,0 +1,195 @@
+id: chai_expect_to_node_assert_equal
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.equal($EXPECTED)
+fix: |-
+  assert.equal($ACTUAL, $EXPECTED)
+
+---
+id: chai_expect_to_node_assert_notEqual
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).not.to.equal($EXPECTED)
+fix: |-
+  assert.notEqual($ACTUAL, $EXPECTED)
+
+---
+id: chai_expect_to_node_assert_instanceOf
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).instanceOf($CONSTRUCTOR)
+    - pattern: expect($ACTUAL).instanceof($CONSTRUCTOR)
+fix: |-
+  assert.ok($ACTUAL instanceof $CONSTRUCTOR)
+
+---
+id: chai_expect_to_node_assert_to_be_a_function
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.a($TYPE)
+constraints:
+  TYPE:
+    regex: 'function|string|number|object|boolean'
+fix: |-
+  assert.ok(typeof $ACTUAL === $TYPE)
+
+---
+id: chai_expect_to_node_assert_sinon_calledWith
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.have.been.calledWith($$$ARGS)
+fix: |-
+  assert.ok($ACTUAL.calledWith($$$ARGS))
+
+---
+id: chai_expect_to_node_assert_sinon_not_calledWith
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).to.not.have.been.calledWith($$$ARGS)
+    - pattern: expect($ACTUAL).not.to.have.been.calledWith($$$ARGS)
+fix: |-
+  assert.equal($ACTUAL.calledWith($$$ARGS), false)
+
+---
+id: chai_expect_to_node_assert_to_be_ok
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.ok
+fix: |-
+  assert.ok($ACTUAL)
+
+---
+id: chai_expect_to_node_assert_not_to_be_ok
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.be.ok
+    - pattern: expect($ACTUAL).to.not.be.ok
+fix: |-
+  assert.equal(!$ACTUAL, true)
+
+---
+id: chai_expect_to_node_assert_sinon_to_have_been_called
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.have.been.called
+fix: |-
+  assert.ok($ACTUAL.called)
+
+---
+id: chai_expect_to_node_assert_sinon_not_to_have_been_called
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.have.been.called
+    - pattern: expect($ACTUAL).to.not.have.been.called
+fix: |-
+  assert.equal($ACTUAL.called, false)
+
+---
+id: chai_expect_to_node_assert_to_be_greaterThanOrEqual
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.greaterThanOrEqual($VAL)
+fix: |-
+  assert.ok($ACTUAL >= $VAL)
+
+---
+id: chai_expect_to_node_assert_to_be_greaterThan
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.greaterThan($VAL)
+fix: |-
+  assert.ok($ACTUAL > $VAL)
+
+---
+id: chai_expect_to_node_assert_to_be_lessThan
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.lessThan($VAL)
+fix: |-
+  assert.ok($ACTUAL < $VAL)
+
+---
+id: chai_expect_to_node_assert_to_be_lessThanOrEqual
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.lessThanOrEqual($VAL)
+fix: |-
+  assert.ok($ACTUAL <= $VAL)
+
+---
+id: chai_expect_to_node_assert_not_to_be_greaterThanOrEqual
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.be.greaterThanOrEqual($VAL)
+    - pattern: expect($ACTUAL).to.not.be.greaterThanOrEqual($VAL)
+fix: |-
+  assert.equal($ACTUAL >= $VAL, false)
+
+---
+id: chai_expect_to_node_assert_not_to_be_greaterThan
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.be.greaterThan($VAL)
+    - pattern: expect($ACTUAL).to.not.be.greaterThan($VAL)
+fix: |-
+  assert.equal($ACTUAL > $VAL, false)
+
+---
+id: chai_expect_to_node_assert_not_to_be_lessThan
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.be.lessThan($VAL)
+    - pattern: expect($ACTUAL).to.not.be.lessThan($VAL)
+fix: |-
+  assert.equal($ACTUAL < $VAL, false)
+
+---
+id: chai_expect_to_node_assert_not_to_be_lessThanOrEqual
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.be.lessThanOrEqual($VAL)
+    - pattern: expect($ACTUAL).to.not.be.lessThanOrEqual($VAL)
+fix: |-
+  assert.equal($ACTUAL <= $VAL, false)
+
+---
+id: chai_expect_to_node_assert_sinon_to_have_always_been_calledGeneric
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.have.always.been.$METHOD($$$ARGS)
+constraints:
+  METHOD:
+    regex: '^called'
+transform:
+  METHOD_PART:
+    convert:
+      toCase: capitalize
+      source: $METHOD
+fix: |-
+  assert.ok($ACTUAL.always$METHOD_PART($$$ARGS))
+
+---
+id: chai_expect_to_node_assert_sinon_not_to_have_always_been_calledGeneric
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not..to.have.always.been.$METHOD($$$ARGS)
+    - pattern: expect($ACTUAL).to.not.have.always.been.$METHOD($$$ARGS)
+constraints:
+  METHOD:
+    regex: '^called'
+transform:
+  METHOD_PART:
+    convert:
+      toCase: capitalize
+      source: $METHOD
+fix: |-
+  assert.equal($ACTUAL.always$METHOD_PART($$$ARGS), false)

--- a/codemods/chai-expect-to-node-assert.yml
+++ b/codemods/chai-expect-to-node-assert.yml
@@ -1,30 +1,26 @@
-id: chai_expect_to_node_assert_equal
-language: TypeScript
-rule:
-  pattern: expect($ACTUAL).to.equal($EXPECTED)
-fix: |-
-  assert.equal($ACTUAL, $EXPECTED)
-
----
-id: chai_expect_to_node_assert_notEqual
-language: TypeScript
-rule:
-  pattern: expect($ACTUAL).not.to.equal($EXPECTED)
-fix: |-
-  assert.notEqual($ACTUAL, $EXPECTED)
-
----
 id: chai_expect_to_node_assert_instanceOf
 language: TypeScript
 rule:
   any:
     - pattern: expect($ACTUAL).instanceOf($CONSTRUCTOR)
     - pattern: expect($ACTUAL).instanceof($CONSTRUCTOR)
+    - pattern: expect($ACTUAL).to.be.instanceOf($CONSTRUCTOR)
 fix: |-
   assert.ok($ACTUAL instanceof $CONSTRUCTOR)
 
 ---
-id: chai_expect_to_node_assert_to_be_a_function
+id: chai_expect_to_node_assert_not_instanceOf
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.instanceOf($CONSTRUCTOR)
+    - pattern: expect($ACTUAL).to.not.be.instanceOf($CONSTRUCTOR)
+    - pattern: expect($ACTUAL).not.to.be.instanceOf($CONSTRUCTOR)
+fix: |-
+  assert.equal($ACTUAL instanceof $CONSTRUCTOR, false)
+
+---
+id: chai_expect_to_node_assert_to_be_a
 language: TypeScript
 rule:
   pattern: expect($ACTUAL).to.be.a($TYPE)
@@ -181,7 +177,7 @@ id: chai_expect_to_node_assert_sinon_not_to_have_always_been_calledGeneric
 language: TypeScript
 rule:
   any:
-    - pattern: expect($ACTUAL).not..to.have.always.been.$METHOD($$$ARGS)
+    - pattern: expect($ACTUAL).not.to.have.always.been.$METHOD($$$ARGS)
     - pattern: expect($ACTUAL).to.not.have.always.been.$METHOD($$$ARGS)
 constraints:
   METHOD:
@@ -193,3 +189,95 @@ transform:
       source: $METHOD
 fix: |-
   assert.equal($ACTUAL.always$METHOD_PART($$$ARGS), false)
+
+---
+id: chai_expect_to_node_assert_to_equal
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).to.equal($EXPECTED)
+    - pattern: expect($ACTUAL).to.be.equal($EXPECTED)
+fix: |-
+  assert.equal($ACTUAL, $EXPECTED)
+
+---
+id: chai_expect_to_node_assert_to_deep_equal
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).to.deep.equal($EXPECTED)
+    - pattern: expect($ACTUAL).to.be.deep.equal($EXPECTED)
+fix: |-
+  assert.deepEqual($ACTUAL, $EXPECTED)
+
+---
+id: chai_expect_to_node_assert_not_to_equal
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.equal($EXPECTED)
+    - pattern: expect($ACTUAL).to.not.equal($EXPECTED)
+    - pattern: expect($ACTUAL).not.to.be.equal($EXPECTED)
+    - pattern: expect($ACTUAL).to.not.be.equal($EXPECTED)
+fix: |-
+  assert.notEqual($ACTUAL, $EXPECTED)
+
+---
+id: chai_expect_to_node_assert_not_to_deep_equal
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).to.not.deep.equal($EXPECTED)
+    - pattern: expect($ACTUAL).not.to.deep.equal($EXPECTED)
+    - pattern: expect($ACTUAL).to.not.be.deep.equal($EXPECTED)
+    - pattern: expect($ACTUAL).not.to.be.deep.equal($EXPECTED)
+fix: |-
+  assert.notDeepEqual($ACTUAL, $EXPECTED)
+
+---
+id: chai_expect_to_node_assert_to_be_trueFalse
+language: TypeScript
+rule:
+  pattern: expect($ACTUAL).to.be.$TRUEFALSE
+constraints:
+  TRUEFALSE:
+    regex: '^true|false$'
+fix: |-
+  assert.equal($ACTUAL, $TRUEFALSE)
+
+---
+id: chai_expect_to_node_assert_not_to_be_trueFalse
+language: TypeScript
+rule:
+  any:
+    - pattern: expect($ACTUAL).not.to.be.$TRUEFALSE
+    - pattern: expect($ACTUAL).to.not.be.$TRUEFALSE
+constraints:
+  TRUEFALSE:
+    regex: '^true|false$'
+fix: |-
+  assert.notEqual($ACTUAL, $TRUEFALSE)
+
+---
+id: chai_expect_to_node_assert_to_be_a_promise
+language: TypeScript
+rule:
+  pattern:
+    context: expect($ACTUAL).to.be.a('promise')
+    strictness: relaxed
+fix: |-
+  assert.ok($ACTUAL instanceof Promise)
+
+---
+id: chai_expect_to_node_assert_not_to_be_a_promise
+language: TypeScript
+rule:
+  any:
+    - pattern:
+        context: expect($ACTUAL).to.not.be.a('promise')
+        strictness: relaxed
+    - pattern:
+        context: expect($ACTUAL).not.to.be.a('promise')
+        strictness: relaxed
+fix: |-
+  assert.equal($ACTUAL instanceof Promise, false)

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_instanceOf-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_instanceOf-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_instanceOf
+snapshots:
+  expect(val).instanceOf(AbortController):
+    fixed: assert.ok(val instanceof AbortController)
+    labels:
+    - source: expect(val).instanceOf(AbortController)
+      style: primary
+      start: 0
+      end: 39
+  expect(val).to.be.instanceOf(AbortController):
+    fixed: assert.ok(val instanceof AbortController)
+    labels:
+    - source: expect(val).to.be.instanceOf(AbortController)
+      style: primary
+      start: 0
+      end: 45

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_instanceOf-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_instanceOf-snapshot.yml
@@ -1,0 +1,23 @@
+id: chai_expect_to_node_assert_not_instanceOf
+snapshots:
+  expect(val).not.instanceOf(AbortController):
+    fixed: assert.equal(val instanceof AbortController, false)
+    labels:
+    - source: expect(val).not.instanceOf(AbortController)
+      style: primary
+      start: 0
+      end: 43
+  expect(val).not.to.be.instanceOf(AbortController):
+    fixed: assert.equal(val instanceof AbortController, false)
+    labels:
+    - source: expect(val).not.to.be.instanceOf(AbortController)
+      style: primary
+      start: 0
+      end: 49
+  expect(val).to.not.be.instanceOf(AbortController):
+    fixed: assert.equal(val instanceof AbortController, false)
+    labels:
+    - source: expect(val).to.not.be.instanceOf(AbortController)
+      style: primary
+      start: 0
+      end: 49

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_a_promise-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_a_promise-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_a_promise
+snapshots:
+  expect(val).not.to.be.a("promise"):
+    fixed: assert.equal(val instanceof Promise, false)
+    labels:
+    - source: expect(val).not.to.be.a("promise")
+      style: primary
+      start: 0
+      end: 34
+  expect(val).not.to.be.a('promise'):
+    fixed: assert.equal(val instanceof Promise, false)
+    labels:
+    - source: expect(val).not.to.be.a('promise')
+      style: primary
+      start: 0
+      end: 34
+  expect(val).to.not.be.a("promise"):
+    fixed: assert.equal(val instanceof Promise, false)
+    labels:
+    - source: expect(val).to.not.be.a("promise")
+      style: primary
+      start: 0
+      end: 34
+  expect(val).to.not.be.a('promise'):
+    fixed: assert.equal(val instanceof Promise, false)
+    labels:
+    - source: expect(val).to.not.be.a('promise')
+      style: primary
+      start: 0
+      end: 34

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_greaterThan-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_greaterThan-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_greaterThan
+snapshots:
+  expect(fn()).not.to.be.greaterThan(303):
+    fixed: assert.equal(fn() > 303, false)
+    labels:
+    - source: expect(fn()).not.to.be.greaterThan(303)
+      style: primary
+      start: 0
+      end: 39
+  expect(fn()).to.not.be.greaterThan(303):
+    fixed: assert.equal(fn() > 303, false)
+    labels:
+    - source: expect(fn()).to.not.be.greaterThan(303)
+      style: primary
+      start: 0
+      end: 39
+  expect(val).not.to.be.greaterThan(303):
+    fixed: assert.equal(val > 303, false)
+    labels:
+    - source: expect(val).not.to.be.greaterThan(303)
+      style: primary
+      start: 0
+      end: 38
+  expect(val).to.not.be.greaterThan(303):
+    fixed: assert.equal(val > 303, false)
+    labels:
+    - source: expect(val).to.not.be.greaterThan(303)
+      style: primary
+      start: 0
+      end: 38

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_greaterThanOrEqual-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_greaterThanOrEqual-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_greaterThanOrEqual
+snapshots:
+  expect(fn()).not.to.be.greaterThanOrEqual(303):
+    fixed: assert.equal(fn() >= 303, false)
+    labels:
+    - source: expect(fn()).not.to.be.greaterThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 46
+  expect(fn()).to.not.be.greaterThanOrEqual(303):
+    fixed: assert.equal(fn() >= 303, false)
+    labels:
+    - source: expect(fn()).to.not.be.greaterThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 46
+  expect(val).not.to.be.greaterThanOrEqual(303):
+    fixed: assert.equal(val >= 303, false)
+    labels:
+    - source: expect(val).not.to.be.greaterThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 45
+  expect(val).to.not.be.greaterThanOrEqual(303):
+    fixed: assert.equal(val >= 303, false)
+    labels:
+    - source: expect(val).to.not.be.greaterThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 45

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_lessThan-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_lessThan-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_lessThan
+snapshots:
+  expect(fn()).not.to.be.lessThan(303):
+    fixed: assert.equal(fn() < 303, false)
+    labels:
+    - source: expect(fn()).not.to.be.lessThan(303)
+      style: primary
+      start: 0
+      end: 36
+  expect(fn()).to.not.be.lessThan(303):
+    fixed: assert.equal(fn() < 303, false)
+    labels:
+    - source: expect(fn()).to.not.be.lessThan(303)
+      style: primary
+      start: 0
+      end: 36
+  expect(val).not.to.be.lessThan(303):
+    fixed: assert.equal(val < 303, false)
+    labels:
+    - source: expect(val).not.to.be.lessThan(303)
+      style: primary
+      start: 0
+      end: 35
+  expect(val).to.not.be.lessThan(303):
+    fixed: assert.equal(val < 303, false)
+    labels:
+    - source: expect(val).to.not.be.lessThan(303)
+      style: primary
+      start: 0
+      end: 35

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_lessThanOrEqual-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_lessThanOrEqual-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_lessThanOrEqual
+snapshots:
+  expect(fn()).not.to.be.lessThanOrEqual(303):
+    fixed: assert.equal(fn() <= 303, false)
+    labels:
+    - source: expect(fn()).not.to.be.lessThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 43
+  expect(fn()).to.not.be.lessThanOrEqual(303):
+    fixed: assert.equal(fn() <= 303, false)
+    labels:
+    - source: expect(fn()).to.not.be.lessThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 43
+  expect(val).not.to.be.lessThanOrEqual(303):
+    fixed: assert.equal(val <= 303, false)
+    labels:
+    - source: expect(val).not.to.be.lessThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 42
+  expect(val).to.not.be.lessThanOrEqual(303):
+    fixed: assert.equal(val <= 303, false)
+    labels:
+    - source: expect(val).to.not.be.lessThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 42

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_ok-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_ok-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_ok
+snapshots:
+  expect(fn()).not.to.be.ok:
+    fixed: assert.equal(!fn(), true)
+    labels:
+    - source: expect(fn()).not.to.be.ok
+      style: primary
+      start: 0
+      end: 25
+  expect(fn()).to.not.be.ok:
+    fixed: assert.equal(!fn(), true)
+    labels:
+    - source: expect(fn()).to.not.be.ok
+      style: primary
+      start: 0
+      end: 25
+  expect(val).not.to.be.ok:
+    fixed: assert.equal(!val, true)
+    labels:
+    - source: expect(val).not.to.be.ok
+      style: primary
+      start: 0
+      end: 24
+  expect(val).to.not.be.ok:
+    fixed: assert.equal(!val, true)
+    labels:
+    - source: expect(val).to.not.be.ok
+      style: primary
+      start: 0
+      end: 24

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_trueFalse-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_be_trueFalse-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_not_to_be_trueFalse
+snapshots:
+  expect(val).not.to.be.false:
+    fixed: assert.notEqual(val, false)
+    labels:
+    - source: expect(val).not.to.be.false
+      style: primary
+      start: 0
+      end: 27
+  expect(val).not.to.be.true:
+    fixed: assert.notEqual(val, true)
+    labels:
+    - source: expect(val).not.to.be.true
+      style: primary
+      start: 0
+      end: 26
+  expect(val).to.not.be.false:
+    fixed: assert.notEqual(val, false)
+    labels:
+    - source: expect(val).to.not.be.false
+      style: primary
+      start: 0
+      end: 27
+  expect(val).to.not.be.true:
+    fixed: assert.notEqual(val, true)
+    labels:
+    - source: expect(val).to.not.be.true
+      style: primary
+      start: 0
+      end: 26

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_deep_equal-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_deep_equal-snapshot.yml
@@ -1,0 +1,44 @@
+id: chai_expect_to_node_assert_not_to_deep_equal
+snapshots:
+  expect(actual).not.to.be.deep.equal(exp):
+    fixed: assert.notDeepEqual(actual, exp)
+    labels:
+    - source: expect(actual).not.to.be.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 40
+  expect(actual).not.to.deep.equal(exp):
+    fixed: assert.notDeepEqual(actual, exp)
+    labels:
+    - source: expect(actual).not.to.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 37
+  expect(actual).to.not.be.deep.equal(exp):
+    fixed: assert.notDeepEqual(actual, exp)
+    labels:
+    - source: expect(actual).to.not.be.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 40
+  expect(actual).to.not.deep.equal(exp):
+    fixed: assert.notDeepEqual(actual, exp)
+    labels:
+    - source: expect(actual).to.not.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 37
+  expect(fn()).not.to.deep.equal(exp):
+    fixed: assert.notDeepEqual(fn(), exp)
+    labels:
+    - source: expect(fn()).not.to.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 35
+  expect(fn()).to.not.deep.equal(exp):
+    fixed: assert.notDeepEqual(fn(), exp)
+    labels:
+    - source: expect(fn()).to.not.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 35

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_equal-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_not_to_equal-snapshot.yml
@@ -1,0 +1,44 @@
+id: chai_expect_to_node_assert_not_to_equal
+snapshots:
+  expect(303).not.to.be.equal(808):
+    fixed: assert.notEqual(303, 808)
+    labels:
+    - source: expect(303).not.to.be.equal(808)
+      style: primary
+      start: 0
+      end: 32
+  expect(303).not.to.equal(808):
+    fixed: assert.notEqual(303, 808)
+    labels:
+    - source: expect(303).not.to.equal(808)
+      style: primary
+      start: 0
+      end: 29
+  expect(303).to.not.be.equal(808):
+    fixed: assert.notEqual(303, 808)
+    labels:
+    - source: expect(303).to.not.be.equal(808)
+      style: primary
+      start: 0
+      end: 32
+  expect(303).to.not.equal(808):
+    fixed: assert.notEqual(303, 808)
+    labels:
+    - source: expect(303).to.not.equal(808)
+      style: primary
+      start: 0
+      end: 29
+  expect(fn()).not.to.equal(303):
+    fixed: assert.notEqual(fn(), 303)
+    labels:
+    - source: expect(fn()).not.to.equal(303)
+      style: primary
+      start: 0
+      end: 30
+  expect(fn()).to.not.equal(303):
+    fixed: assert.notEqual(fn(), 303)
+    labels:
+    - source: expect(fn()).to.not.equal(303)
+      style: primary
+      start: 0
+      end: 30

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_calledWith-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_calledWith-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_sinon_calledWith
+snapshots:
+  expect(foo()).to.have.been.calledWith(3, 0, 3):
+    fixed: assert.ok(foo().calledWith(3, 0, 3))
+    labels:
+    - source: expect(foo()).to.have.been.calledWith(3, 0, 3)
+      style: primary
+      start: 0
+      end: 46
+  expect(val).to.have.been.calledWith(3, 0, 3):
+    fixed: assert.ok(val.calledWith(3, 0, 3))
+    labels:
+    - source: expect(val).to.have.been.calledWith(3, 0, 3)
+      style: primary
+      start: 0
+      end: 44

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_not_calledWith-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_not_calledWith-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_sinon_not_calledWith
+snapshots:
+  expect(foo()).not.to.have.been.calledWith(3, 0, 3):
+    fixed: assert.equal(foo().calledWith(3, 0, 3), false)
+    labels:
+    - source: expect(foo()).not.to.have.been.calledWith(3, 0, 3)
+      style: primary
+      start: 0
+      end: 50
+  expect(foo()).to.not.have.been.calledWith(3, 0, 3):
+    fixed: assert.equal(foo().calledWith(3, 0, 3), false)
+    labels:
+    - source: expect(foo()).to.not.have.been.calledWith(3, 0, 3)
+      style: primary
+      start: 0
+      end: 50
+  expect(val).not.to.have.been.calledWith(3, 0, 3):
+    fixed: assert.equal(val.calledWith(3, 0, 3), false)
+    labels:
+    - source: expect(val).not.to.have.been.calledWith(3, 0, 3)
+      style: primary
+      start: 0
+      end: 48
+  expect(val).to.not.have.been.calledWith(3, 0, 3):
+    fixed: assert.equal(val.calledWith(3, 0, 3), false)
+    labels:
+    - source: expect(val).to.not.have.been.calledWith(3, 0, 3)
+      style: primary
+      start: 0
+      end: 48

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_not_to_have_always_been_calledGeneric-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_not_to_have_always_been_calledGeneric-snapshot.yml
@@ -1,0 +1,58 @@
+id: chai_expect_to_node_assert_sinon_not_to_have_always_been_calledGeneric
+snapshots:
+  expect(spy).not.to.have.always.been.calledWith(303):
+    fixed: assert.equal(spy.alwaysCalledWith(303), false)
+    labels:
+    - source: expect(spy).not.to.have.always.been.calledWith(303)
+      style: primary
+      start: 0
+      end: 51
+  expect(spy).not.to.have.always.been.calledWith(303, 808):
+    fixed: assert.equal(spy.alwaysCalledWith(303, 808), false)
+    labels:
+    - source: expect(spy).not.to.have.always.been.calledWith(303, 808)
+      style: primary
+      start: 0
+      end: 56
+  expect(spy).not.to.have.always.been.calledWithExactly(303, 808):
+    fixed: assert.equal(spy.alwaysCalledWithExactly(303, 808), false)
+    labels:
+    - source: expect(spy).not.to.have.always.been.calledWithExactly(303, 808)
+      style: primary
+      start: 0
+      end: 63
+  expect(spy).not.to.have.always.been.calledWithMatch(exp):
+    fixed: assert.equal(spy.alwaysCalledWithMatch(exp), false)
+    labels:
+    - source: expect(spy).not.to.have.always.been.calledWithMatch(exp)
+      style: primary
+      start: 0
+      end: 56
+  expect(spy).to.not.have.always.been.calledWith(303):
+    fixed: assert.equal(spy.alwaysCalledWith(303), false)
+    labels:
+    - source: expect(spy).to.not.have.always.been.calledWith(303)
+      style: primary
+      start: 0
+      end: 51
+  expect(spy).to.not.have.always.been.calledWith(303, 808):
+    fixed: assert.equal(spy.alwaysCalledWith(303, 808), false)
+    labels:
+    - source: expect(spy).to.not.have.always.been.calledWith(303, 808)
+      style: primary
+      start: 0
+      end: 56
+  expect(spy).to.not.have.always.been.calledWithExactly(303, 808):
+    fixed: assert.equal(spy.alwaysCalledWithExactly(303, 808), false)
+    labels:
+    - source: expect(spy).to.not.have.always.been.calledWithExactly(303, 808)
+      style: primary
+      start: 0
+      end: 63
+  expect(spy).to.not.have.always.been.calledWithMatch(exp):
+    fixed: assert.equal(spy.alwaysCalledWithMatch(exp), false)
+    labels:
+    - source: expect(spy).to.not.have.always.been.calledWithMatch(exp)
+      style: primary
+      start: 0
+      end: 56

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_not_to_have_been_called-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_not_to_have_been_called-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_sinon_not_to_have_been_called
+snapshots:
+  expect(fn()).not.to.have.been.called:
+    fixed: assert.equal(fn().called, false)
+    labels:
+    - source: expect(fn()).not.to.have.been.called
+      style: primary
+      start: 0
+      end: 36
+  expect(fn()).to.not.have.been.called:
+    fixed: assert.equal(fn().called, false)
+    labels:
+    - source: expect(fn()).to.not.have.been.called
+      style: primary
+      start: 0
+      end: 36
+  expect(spy).not.to.have.been.called:
+    fixed: assert.equal(spy.called, false)
+    labels:
+    - source: expect(spy).not.to.have.been.called
+      style: primary
+      start: 0
+      end: 35
+  expect(spy).to.not.have.been.called:
+    fixed: assert.equal(spy.called, false)
+    labels:
+    - source: expect(spy).to.not.have.been.called
+      style: primary
+      start: 0
+      end: 35

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_to_have_always_been_calledGeneric-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_to_have_always_been_calledGeneric-snapshot.yml
@@ -1,0 +1,30 @@
+id: chai_expect_to_node_assert_sinon_to_have_always_been_calledGeneric
+snapshots:
+  expect(spy).to.have.always.been.calledWith(303):
+    fixed: assert.ok(spy.alwaysCalledWith(303))
+    labels:
+    - source: expect(spy).to.have.always.been.calledWith(303)
+      style: primary
+      start: 0
+      end: 47
+  expect(spy).to.have.always.been.calledWith(303, 808):
+    fixed: assert.ok(spy.alwaysCalledWith(303, 808))
+    labels:
+    - source: expect(spy).to.have.always.been.calledWith(303, 808)
+      style: primary
+      start: 0
+      end: 52
+  expect(spy).to.have.always.been.calledWithExactly(303, 808):
+    fixed: assert.ok(spy.alwaysCalledWithExactly(303, 808))
+    labels:
+    - source: expect(spy).to.have.always.been.calledWithExactly(303, 808)
+      style: primary
+      start: 0
+      end: 59
+  expect(spy).to.have.always.been.calledWithMatch(exp):
+    fixed: assert.ok(spy.alwaysCalledWithMatch(exp))
+    labels:
+    - source: expect(spy).to.have.always.been.calledWithMatch(exp)
+      style: primary
+      start: 0
+      end: 52

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_to_have_been_called-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_sinon_to_have_been_called-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_sinon_to_have_been_called
+snapshots:
+  expect(fn()).to.have.been.called:
+    fixed: assert.ok(fn().called)
+    labels:
+    - source: expect(fn()).to.have.been.called
+      style: primary
+      start: 0
+      end: 32
+  expect(spy).to.have.been.called:
+    fixed: assert.ok(spy.called)
+    labels:
+    - source: expect(spy).to.have.been.called
+      style: primary
+      start: 0
+      end: 31

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_a-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_a-snapshot.yml
@@ -1,0 +1,37 @@
+id: chai_expect_to_node_assert_to_be_a
+snapshots:
+  expect(val).to.be.a('boolean'):
+    fixed: assert.ok(typeof val === 'boolean')
+    labels:
+    - source: expect(val).to.be.a('boolean')
+      style: primary
+      start: 0
+      end: 30
+  expect(val).to.be.a('function'):
+    fixed: assert.ok(typeof val === 'function')
+    labels:
+    - source: expect(val).to.be.a('function')
+      style: primary
+      start: 0
+      end: 31
+  expect(val).to.be.a('number'):
+    fixed: assert.ok(typeof val === 'number')
+    labels:
+    - source: expect(val).to.be.a('number')
+      style: primary
+      start: 0
+      end: 29
+  expect(val).to.be.a('object'):
+    fixed: assert.ok(typeof val === 'object')
+    labels:
+    - source: expect(val).to.be.a('object')
+      style: primary
+      start: 0
+      end: 29
+  expect(val).to.be.a('string'):
+    fixed: assert.ok(typeof val === 'string')
+    labels:
+    - source: expect(val).to.be.a('string')
+      style: primary
+      start: 0
+      end: 29

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_a_promise-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_a_promise-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_a_promise
+snapshots:
+  expect(val).to.be.a("promise"):
+    fixed: assert.ok(val instanceof Promise)
+    labels:
+    - source: expect(val).to.be.a("promise")
+      style: primary
+      start: 0
+      end: 30
+  expect(val).to.be.a('promise'):
+    fixed: assert.ok(val instanceof Promise)
+    labels:
+    - source: expect(val).to.be.a('promise')
+      style: primary
+      start: 0
+      end: 30

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_greaterThan-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_greaterThan-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_greaterThan
+snapshots:
+  expect(fn()).to.be.greaterThan(303):
+    fixed: assert.ok(fn() > 303)
+    labels:
+    - source: expect(fn()).to.be.greaterThan(303)
+      style: primary
+      start: 0
+      end: 35
+  expect(val).to.be.greaterThan(303):
+    fixed: assert.ok(val > 303)
+    labels:
+    - source: expect(val).to.be.greaterThan(303)
+      style: primary
+      start: 0
+      end: 34

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_greaterThanOrEqual-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_greaterThanOrEqual-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_greaterThanOrEqual
+snapshots:
+  expect(fn()).to.be.greaterThanOrEqual(303):
+    fixed: assert.ok(fn() >= 303)
+    labels:
+    - source: expect(fn()).to.be.greaterThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 42
+  expect(val).to.be.greaterThanOrEqual(303):
+    fixed: assert.ok(val >= 303)
+    labels:
+    - source: expect(val).to.be.greaterThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 41

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_lessThan-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_lessThan-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_lessThan
+snapshots:
+  expect(fn()).to.be.lessThan(303):
+    fixed: assert.ok(fn() < 303)
+    labels:
+    - source: expect(fn()).to.be.lessThan(303)
+      style: primary
+      start: 0
+      end: 32
+  expect(val).to.be.lessThan(303):
+    fixed: assert.ok(val < 303)
+    labels:
+    - source: expect(val).to.be.lessThan(303)
+      style: primary
+      start: 0
+      end: 31

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_lessThanOrEqual-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_lessThanOrEqual-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_lessThanOrEqual
+snapshots:
+  expect(fn()).to.be.lessThanOrEqual(303):
+    fixed: assert.ok(fn() <= 303)
+    labels:
+    - source: expect(fn()).to.be.lessThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 39
+  expect(val).to.be.lessThanOrEqual(303):
+    fixed: assert.ok(val <= 303)
+    labels:
+    - source: expect(val).to.be.lessThanOrEqual(303)
+      style: primary
+      start: 0
+      end: 38

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_ok-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_ok-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_ok
+snapshots:
+  expect(fn()).to.be.ok:
+    fixed: assert.ok(fn())
+    labels:
+    - source: expect(fn()).to.be.ok
+      style: primary
+      start: 0
+      end: 21
+  expect(val).to.be.ok:
+    fixed: assert.ok(val)
+    labels:
+    - source: expect(val).to.be.ok
+      style: primary
+      start: 0
+      end: 20

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_trueFalse-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_be_trueFalse-snapshot.yml
@@ -1,0 +1,16 @@
+id: chai_expect_to_node_assert_to_be_trueFalse
+snapshots:
+  expect(val).to.be.false:
+    fixed: assert.equal(val, false)
+    labels:
+    - source: expect(val).to.be.false
+      style: primary
+      start: 0
+      end: 23
+  expect(val).to.be.true:
+    fixed: assert.equal(val, true)
+    labels:
+    - source: expect(val).to.be.true
+      style: primary
+      start: 0
+      end: 22

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_deep_equal-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_deep_equal-snapshot.yml
@@ -1,0 +1,23 @@
+id: chai_expect_to_node_assert_to_deep_equal
+snapshots:
+  expect(actual).to.be.deep.equal(exp):
+    fixed: assert.deepEqual(actual, exp)
+    labels:
+    - source: expect(actual).to.be.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 36
+  expect(actual).to.deep.equal(exp):
+    fixed: assert.deepEqual(actual, exp)
+    labels:
+    - source: expect(actual).to.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 33
+  expect(fn()).to.deep.equal(exp):
+    fixed: assert.deepEqual(fn(), exp)
+    labels:
+    - source: expect(fn()).to.deep.equal(exp)
+      style: primary
+      start: 0
+      end: 31

--- a/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_equal-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/chai_expect_to_node_assert_to_equal-snapshot.yml
@@ -1,0 +1,23 @@
+id: chai_expect_to_node_assert_to_equal
+snapshots:
+  expect(303).to.be.equal(808):
+    fixed: assert.equal(303, 808)
+    labels:
+    - source: expect(303).to.be.equal(808)
+      style: primary
+      start: 0
+      end: 28
+  expect(303).to.equal(808):
+    fixed: assert.equal(303, 808)
+    labels:
+    - source: expect(303).to.equal(808)
+      style: primary
+      start: 0
+      end: 25
+  expect(fn()).to.equal(303):
+    fixed: assert.equal(fn(), 303)
+    labels:
+    - source: expect(fn()).to.equal(303)
+      style: primary
+      start: 0
+      end: 26

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-instanceof.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-instanceof.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_instanceOf
+valid:
+  - assert.instanceOf(val, AbortController)
+  - expect(val).not.instanceOf(AbortController)
+  - expect(val).not.to.be.instanceOf(AbortController)
+invalid:
+  - expect(val).to.be.instanceOf(AbortController)
+  - expect(val).instanceOf(AbortController)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-instanceof.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-instanceof.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_not_instanceOf
+valid:
+  - expect(val).instanceOf(AbortController)
+  - expect(val).to.be.instanceOf(AbortController)
+invalid:
+  - expect(val).to.not.be.instanceOf(AbortController)
+  - expect(val).not.to.be.instanceOf(AbortController)
+  - expect(val).not.instanceOf(AbortController)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-sinon-to-have-always-been-calledgeneric.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-sinon-to-have-always-been-calledgeneric.yml
@@ -1,0 +1,15 @@
+id: chai_expect_to_node_assert_sinon_not_to_have_always_been_calledGeneric
+valid:
+  - assert.equal(spy.alwaysCalledWith(303), false)
+  - expect(spy.alwaysCalledWith(303)).to.be.false
+  - expect(spy).not.to.have.always.been.called
+  - expect(spy).not.to.have.always.been.oogaboogad(303)
+invalid:
+  - expect(spy).not.to.have.always.been.calledWith(303)
+  - expect(spy).not.to.have.always.been.calledWith(303, 808)
+  - expect(spy).not.to.have.always.been.calledWithExactly(303, 808)
+  - expect(spy).not.to.have.always.been.calledWithMatch(exp)
+  - expect(spy).to.not.have.always.been.calledWith(303)
+  - expect(spy).to.not.have.always.been.calledWith(303, 808)
+  - expect(spy).to.not.have.always.been.calledWithExactly(303, 808)
+  - expect(spy).to.not.have.always.been.calledWithMatch(exp)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-a-promise.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-a-promise.yml
@@ -1,0 +1,11 @@
+id: chai_expect_to_node_assert_not_to_be_a_promise
+valid:
+  - assert.equal(val instanceof Promise, false)
+  - expect(val).not.to.be.a('function')
+  - expect(val).to.be.a('promise')
+  - expect(val instanceof Promise).to.be.false
+invalid:
+  - expect(val).not.to.be.a('promise')
+  - expect(val).not.to.be.a("promise")
+  - expect(val).to.not.be.a('promise')
+  - expect(val).to.not.be.a("promise")

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-greaterthan.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-greaterthan.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_not_to_be_greaterThan
+valid:
+  - expect(val).to.be.greaterThan(42)
+  - assert.ok(val >= 303)
+  - expect(val).not.to.be.greaterThanOrEqual(303)
+invalid:
+  - expect(val).not.to.be.greaterThan(303)
+  - expect(fn()).not.to.be.greaterThan(303)
+  - expect(val).to.not.be.greaterThan(303)
+  - expect(fn()).to.not.be.greaterThan(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-greaterthanorequal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-greaterthanorequal.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_not_to_be_greaterThanOrEqual
+valid:
+  - expect(val).to.be.greaterThanOrEqual(42)
+  - assert.ok(val >= 303)
+  - expect(val).not.to.be.greaterThan(303)
+invalid:
+  - expect(val).not.to.be.greaterThanOrEqual(303)
+  - expect(fn()).not.to.be.greaterThanOrEqual(303)
+  - expect(val).to.not.be.greaterThanOrEqual(303)
+  - expect(fn()).to.not.be.greaterThanOrEqual(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-lessthan.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-lessthan.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_not_to_be_lessThan
+valid:
+  - expect(val).to.be.lessThan(42)
+  - assert.ok(val >= 303)
+  - expect(val).not.to.be.lessThanOrEqual(303)
+invalid:
+  - expect(val).not.to.be.lessThan(303)
+  - expect(fn()).not.to.be.lessThan(303)
+  - expect(val).to.not.be.lessThan(303)
+  - expect(fn()).to.not.be.lessThan(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-lessthanorequal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-lessthanorequal.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_not_to_be_lessThanOrEqual
+valid:
+  - expect(val).to.be.lessThanOrEqual(42)
+  - assert.ok(val >= 303)
+  - expect(val).not.to.be.lessThan(303)
+invalid:
+  - expect(val).not.to.be.lessThanOrEqual(303)
+  - expect(fn()).not.to.be.lessThanOrEqual(303)
+  - expect(val).to.not.be.lessThanOrEqual(303)
+  - expect(fn()).to.not.be.lessThanOrEqual(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-ok.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-ok.yml
@@ -1,0 +1,9 @@
+id: chai_expect_to_node_assert_not_to_be_ok
+valid:
+  - expect(val).to.be.ok
+  - assert.equal(val, false)
+invalid:
+  - expect(val).not.to.be.ok
+  - expect(fn()).not.to.be.ok
+  - expect(val).to.not.be.ok
+  - expect(fn()).to.not.be.ok

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-truefalse.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-be-truefalse.yml
@@ -1,0 +1,11 @@
+id: chai_expect_to_node_assert_not_to_be_trueFalse
+valid:
+  - assert.equal(val, false)
+  - expect(val).not.to.equal(true)
+  - expect(val).to.be.true
+  - expect(val).to.be.false
+invalid:
+  - expect(val).not.to.be.true
+  - expect(val).not.to.be.false
+  - expect(val).to.not.be.true
+  - expect(val).to.not.be.false

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-deep-equal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-deep-equal.yml
@@ -1,0 +1,11 @@
+id: chai_expect_to_node_assert_not_to_deep_equal
+valid:
+  - assert.equal(303, 808)
+  - expect(actual).not.to.equal(exp)
+invalid:
+  - expect(actual).not.to.deep.equal(exp)
+  - expect(actual).not.to.be.deep.equal(exp)
+  - expect(fn()).not.to.deep.equal(exp)
+  - expect(actual).to.not.deep.equal(exp)
+  - expect(actual).to.not.be.deep.equal(exp)
+  - expect(fn()).to.not.deep.equal(exp)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-equal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-not-to-equal.yml
@@ -1,0 +1,12 @@
+id: chai_expect_to_node_assert_not_to_equal
+valid:
+  - assert.equal(303, 808)
+  - expect(303).to.equal(808)
+  - expect(actual).not.to.deep.equal(exp)
+invalid:
+  - expect(303).not.to.equal(808)
+  - expect(303).not.to.be.equal(808)
+  - expect(fn()).not.to.equal(303)
+  - expect(303).to.not.equal(808)
+  - expect(303).to.not.be.equal(808)
+  - expect(fn()).to.not.equal(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-calledwith.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-calledwith.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_sinon_calledWith
+valid:
+  - expect(val).to.have.been.called
+  - assert.ok(val.calledWith(3, 0, 3))
+  - expect(val).not.to.have.been.calledWith(3, 0, 3)
+invalid:
+  - expect(val).to.have.been.calledWith(3, 0, 3)
+  - expect(foo()).to.have.been.calledWith(3, 0, 3)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-not-calledwith.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-not-calledwith.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_sinon_not_calledWith
+valid:
+  - expect(val).not.to.have.been.called
+  - assert.equal(val.calledWith(3, 0, 3), false)
+  - expect(val).to.have.been.calledWith(3, 0, 3)
+invalid:
+  - expect(val).not.to.have.been.calledWith(3, 0, 3)
+  - expect(foo()).not.to.have.been.calledWith(3, 0, 3)
+  - expect(val).to.not.have.been.calledWith(3, 0, 3)
+  - expect(foo()).to.not.have.been.calledWith(3, 0, 3)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-not-to-have-been-called.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-not-to-have-been-called.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_sinon_not_to_have_been_called
+valid:
+  - expect(spy).to.have.been.called
+  - assert.equal(spy.called, false)
+  - expect(spy.called).to.be.false
+invalid:
+  - expect(spy).not.to.have.been.called
+  - expect(fn()).not.to.have.been.called
+  - expect(spy).to.not.have.been.called
+  - expect(fn()).to.not.have.been.called

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-to-have-always-been-calledgeneric.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-to-have-always-been-calledgeneric.yml
@@ -1,0 +1,11 @@
+id: chai_expect_to_node_assert_sinon_to_have_always_been_calledGeneric
+valid:
+  - assert.ok(spy.alwaysCalledWith(303))
+  - expect(spy.alwaysCalledWith(303)).to.be.true
+  - expect(spy).to.have.always.been.called
+  - expect(spy).to.have.always.been.oogaboogad(303)
+invalid:
+  - expect(spy).to.have.always.been.calledWith(303)
+  - expect(spy).to.have.always.been.calledWith(303, 808)
+  - expect(spy).to.have.always.been.calledWithExactly(303, 808)
+  - expect(spy).to.have.always.been.calledWithMatch(exp)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-to-have-been-called.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-sinon-to-have-been-called.yml
@@ -1,0 +1,9 @@
+id: chai_expect_to_node_assert_sinon_to_have_been_called
+valid:
+  - expect(spy).not.to.have.been.called
+  - assert.ok(spy.called)
+  - assert.equal(spy.called, true)
+  - expect(spy.called).to.be.ok
+invalid:
+  - expect(spy).to.have.been.called
+  - expect(fn()).to.have.been.called

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-a-promise.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-a-promise.yml
@@ -1,0 +1,9 @@
+id: chai_expect_to_node_assert_to_be_a_promise
+valid:
+  - assert.ok(val instanceof Promise)
+  - expect(val).to.be.a('function')
+  - expect(val).not.to.be.a('promise')
+  - expect(val instanceof Promise).to.be.true
+invalid:
+  - expect(val).to.be.a('promise')
+  - expect(val).to.be.a("promise")

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-a.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-a.yml
@@ -1,0 +1,11 @@
+id: chai_expect_to_node_assert_to_be_a
+valid:
+  - expect(val).not.to.be.a('function')
+  - expect(val).to.not.be.a('function')
+  - expect(val).to.be.a('promise')
+invalid:
+  - expect(val).to.be.a('function')
+  - expect(val).to.be.a('string')
+  - expect(val).to.be.a('number')
+  - expect(val).to.be.a('object')
+  - expect(val).to.be.a('boolean')

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-greaterthan.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-greaterthan.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_to_be_greaterThan
+valid:
+  - expect(val).to.be.greaterThanOrEqual(42)
+  - assert.ok(val > 303)
+  - expect(val).not.to.be.greaterThan(303)
+invalid:
+  - expect(val).to.be.greaterThan(303)
+  - expect(fn()).to.be.greaterThan(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-greaterthanorequal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-greaterthanorequal.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_to_be_greaterThanOrEqual
+valid:
+  - expect(val).to.be.greaterThan(42)
+  - assert.ok(val >= 303)
+  - expect(val).not.to.be.greaterThanOrEqual(303)
+invalid:
+  - expect(val).to.be.greaterThanOrEqual(303)
+  - expect(fn()).to.be.greaterThanOrEqual(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-lessthan.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-lessthan.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_to_be_lessThan
+valid:
+  - expect(val).to.be.lessThanOrEqual(42)
+  - assert.ok(val < 303)
+  - expect(val).not.to.be.lessThan(303)
+invalid:
+  - expect(val).to.be.lessThan(303)
+  - expect(fn()).to.be.lessThan(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-lessthanorequal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-lessthanorequal.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_to_be_lessThanOrEqual
+valid:
+  - expect(val).to.be.lessThan(42)
+  - assert.ok(val <= 303)
+  - expect(val).not.to.be.lessThanOrEqual(303)
+invalid:
+  - expect(val).to.be.lessThanOrEqual(303)
+  - expect(fn()).to.be.lessThanOrEqual(303)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-ok.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-ok.yml
@@ -1,0 +1,7 @@
+id: chai_expect_to_node_assert_to_be_ok
+valid:
+  - expect(val).not.to.be.ok
+  - assert.ok(val)
+invalid:
+  - expect(val).to.be.ok
+  - expect(fn()).to.be.ok

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-truefalse.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-be-truefalse.yml
@@ -1,0 +1,9 @@
+id: chai_expect_to_node_assert_to_be_trueFalse
+valid:
+  - assert.equal(val, true)
+  - expect(val).to.equal(true)
+  - expect(val).not.to.be.true
+  - expect(val).not.to.be.false
+invalid:
+  - expect(val).to.be.true
+  - expect(val).to.be.false

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-deep-equal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-deep-equal.yml
@@ -1,0 +1,8 @@
+id: chai_expect_to_node_assert_to_deep_equal
+valid:
+  - assert.equal(303, 808)
+  - expect(actual).to.equal(exp)
+invalid:
+  - expect(actual).to.deep.equal(exp)
+  - expect(actual).to.be.deep.equal(exp)
+  - expect(fn()).to.deep.equal(exp)

--- a/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-equal.yml
+++ b/test/sg/codemods/chai-expect-to-node-assert/chai-expect-to-node-assert-to-equal.yml
@@ -1,0 +1,10 @@
+id: chai_expect_to_node_assert_to_equal
+valid:
+  - assert.equal(303, 808)
+  - expect(303).not.to.equal(808)
+  - expect(303).to.be.ok
+  - expect(actual).to.deep.equal(exp)
+invalid:
+  - expect(303).to.equal(808)
+  - expect(303).to.be.equal(808)
+  - expect(fn()).to.equal(303)


### PR DESCRIPTION
adds a codemod for moving from chai's `expect` assertions to `node:assert`