### PR TITLE
feat: add sinon to vitest codemod

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ sg scan -r path-to-codemod.yml path-to-source-code
 | [chai-expect-to-node-assert](./codemods/chai-expect-to-node-assert.yml) | Convert chai `expect` assertions to `node:assert` assertions |
 | [chai-should-to-expect](./codemods/chai-should-to-expect.yml) | Convert `should` assertions to `expect` assertions |
 | [sinon-to-tinyspy](./codemods/sinon-to-tinyspy.yml) | Convert `sinon` spies to `tinyspy` spies |
+| [sinon-to-vitest](./codemods/sinon-to-vitest.yml) | Convert `sinon` spy assertions to vitest assertions |

--- a/codemods/sinon-to-vitest.yml
+++ b/codemods/sinon-to-vitest.yml
@@ -1,0 +1,170 @@
+id: sinon_to_vitest_spy
+language: JavaScript
+rule:
+  pattern: sinon.spy()
+fix: |-
+  vi.fn()
+
+---
+id: sinon_to_vitest_spy_with_args
+language: JavaScript
+rule:
+  pattern: sinon.spy($ARG)
+fix: |-
+  vi.fn($ARG)
+
+---
+id: sinon_to_vitest_stub_with_args
+language: JavaScript
+rule:
+  pattern: sinon.stub($OBJ, $PROP)
+fix: |-
+  vi.spyOn($OBJ, $PROP).mockImplementation(() => {})
+
+---
+id: sinon_to_vitest_match
+language: JavaScript
+rule:
+  pattern: sinon.match($ARG)
+fix: |-
+  expect.objectContaining($ARG)
+
+---
+id: sinon_to_vitest_spy_method
+language: JavaScript
+rule:
+  pattern: sinon.spy($OBJ, $PROP)
+fix: |-
+  vi.spyOn($OBJ, $PROP)
+
+---
+id: sinon_to_vitest_match_func
+language: JavaScript
+rule:
+  pattern: sinon.match.func
+fix: |-
+  expect.any(Function)
+
+---
+id: sinon_to_vitest_expect_called
+language: JavaScript
+rule:
+  pattern: expect($ARG).to.have.been.called
+fix: |-
+  expect($ARG).toHaveBeenCalled()
+
+---
+id: sinon_to_vitest_expect_calledOnce
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.have.been.calledOnce
+    - pattern: expect($ARG).to.be.calledOnce
+fix: |-
+  expect($ARG).toHaveBeenCalledOnce()
+
+---
+id: sinon_to_vitest_expect_calledTwice
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.have.been.calledTwice
+    - pattern: expect($ARG).to.be.calledTwice
+fix: |-
+  expect($ARG).toHaveBeenCalledTimes(2)
+
+---
+id: sinon_to_vitest_expect_calledThrice
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.have.been.calledThrice
+    - pattern: expect($ARG).to.be.calledThrice
+fix: |-
+  expect($ARG).toHaveBeenCalledTimes(3)
+
+---
+id: sinon_to_vitest_expect_not_called
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.not.have.been.called
+    - pattern: expect($ARG).not.to.have.been.called
+fix: |-
+  expect($ARG).not.toHaveBeenCalled()
+
+---
+id: sinon_to_vitest_expect_calledWith
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.have.been.calledWith($$$ARGS)
+    - pattern: expect($ARG).to.have.been.calledWithExactly($$$ARGS)
+fix: |-
+  expect($ARG).toHaveBeenCalledWith($$$ARGS)
+
+---
+id: sinon_to_vitest_expect_not_calledWith
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).not.to.have.been.calledWith($$$ARGS)
+    - pattern: expect($ARG).not.to.have.been.calledWithExactly($$$ARGS)
+fix: |-
+  expect($ARG).not.toHaveBeenCalledWith($$$ARGS)
+
+---
+id: sinon_to_vitest_expect_calledOnce_and_calledWith
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.have.been.calledOnce.and.to.have.been.calledWithMatch($$$ARGS)
+    - pattern: expect($ARG).to.have.been.calledOnce.and.to.have.been.calledWithExactly($$$ARGS)
+    - pattern: expect($ARG).to.have.been.calledOnce.and.to.have.been.calledWith($$$ARGS)
+fix: |-
+  expect($ARG).toHaveBeenCalledOnce();
+  expect($ARG).toHaveBeenCalledWith($$$ARGS)
+
+---
+id: sinon_to_vitest_expect_calledTwice_and_calledWith
+language: JavaScript
+rule:
+  any:
+    - pattern: expect($ARG).to.have.been.calledTwice.and.to.have.been.calledWithMatch($$$ARGS)
+    - pattern: expect($ARG).to.have.been.calledTwice.and.to.have.been.calledWithExactly($$$ARGS)
+    - pattern: expect($ARG).to.have.been.calledTwice.and.to.have.been.calledWith($$$ARGS)
+fix: |-
+  expect($ARG).toHaveBeenCalledTimes(2);
+  expect($ARG).toHaveBeenCalledWith($$$ARGS)
+
+---
+id: sinon_to_vitest_expect_calledWithMatch
+language: JavaScript
+rule:
+  pattern: expect($ARG).to.have.been.calledWithMatch($$$ARGS)
+fix: |-
+  expect($ARG).toHaveBeenCalledWith($$$ARGS)
+
+---
+id: sinon_to_vitest_expect_calledBefore
+language: JavaScript
+rule:
+  pattern: expect($ARG).to.have.been.calledBefore($BEFORE)
+fix: |-
+  expect($ARG).toHaveBeenCalledBefore($BEFORE)
+
+---
+id: sinon_to_vitest_resetHistory
+language: JavaScript
+rule:
+  pattern: $ARG.resetHistory()
+fix: |-
+  $ARG.mockClear()
+
+---
+id: sinon_to_vitest_expect_callCount
+language: JavaScript
+rule:
+  pattern: expect($ARG).to.have.callCount($COUNT)
+fix: |-
+  expect($ARG).toHaveBeenCalledTimes($COUNT)

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_callCount-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_callCount-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_expect_callCount
+snapshots:
+  expect(foo).to.have.callCount(2):
+    fixed: expect(foo).toHaveBeenCalledTimes(2)
+    labels:
+    - source: expect(foo).to.have.callCount(2)
+      style: primary
+      start: 0
+      end: 32

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_called-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_called-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_expect_called
+snapshots:
+  expect(foo).to.have.been.called:
+    fixed: expect(foo).toHaveBeenCalled()
+    labels:
+    - source: expect(foo).to.have.been.called
+      style: primary
+      start: 0
+      end: 31

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledBefore-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledBefore-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_expect_calledBefore
+snapshots:
+  expect(foo).to.have.been.calledBefore(bar):
+    fixed: expect(foo).toHaveBeenCalledBefore(bar)
+    labels:
+    - source: expect(foo).to.have.been.calledBefore(bar)
+      style: primary
+      start: 0
+      end: 42

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledOnce-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledOnce-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_calledOnce
+snapshots:
+  expect(foo).to.be.calledOnce:
+    fixed: expect(foo).toHaveBeenCalledOnce()
+    labels:
+    - source: expect(foo).to.be.calledOnce
+      style: primary
+      start: 0
+      end: 28
+  expect(foo).to.have.been.calledOnce:
+    fixed: expect(foo).toHaveBeenCalledOnce()
+    labels:
+    - source: expect(foo).to.have.been.calledOnce
+      style: primary
+      start: 0
+      end: 35

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledOnce_and_calledWith-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledOnce_and_calledWith-snapshot.yml
@@ -1,0 +1,29 @@
+id: sinon_to_vitest_expect_calledOnce_and_calledWith
+snapshots:
+  expect(foo).to.have.been.calledOnce.and.to.have.been.calledWith(x, y):
+    fixed: |-
+      expect(foo).toHaveBeenCalledOnce();
+      expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledOnce.and.to.have.been.calledWith(x, y)
+      style: primary
+      start: 0
+      end: 69
+  expect(foo).to.have.been.calledOnce.and.to.have.been.calledWithExactly(x, y):
+    fixed: |-
+      expect(foo).toHaveBeenCalledOnce();
+      expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledOnce.and.to.have.been.calledWithExactly(x, y)
+      style: primary
+      start: 0
+      end: 76
+  expect(foo).to.have.been.calledOnce.and.to.have.been.calledWithMatch(x, y):
+    fixed: |-
+      expect(foo).toHaveBeenCalledOnce();
+      expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledOnce.and.to.have.been.calledWithMatch(x, y)
+      style: primary
+      start: 0
+      end: 74

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledThrice-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledThrice-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_calledThrice
+snapshots:
+  expect(foo).to.be.calledThrice:
+    fixed: expect(foo).toHaveBeenCalledTimes(3)
+    labels:
+    - source: expect(foo).to.be.calledThrice
+      style: primary
+      start: 0
+      end: 30
+  expect(foo).to.have.been.calledThrice:
+    fixed: expect(foo).toHaveBeenCalledTimes(3)
+    labels:
+    - source: expect(foo).to.have.been.calledThrice
+      style: primary
+      start: 0
+      end: 37

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledTwice-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledTwice-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_calledTwice
+snapshots:
+  expect(foo).to.be.calledTwice:
+    fixed: expect(foo).toHaveBeenCalledTimes(2)
+    labels:
+    - source: expect(foo).to.be.calledTwice
+      style: primary
+      start: 0
+      end: 29
+  expect(foo).to.have.been.calledTwice:
+    fixed: expect(foo).toHaveBeenCalledTimes(2)
+    labels:
+    - source: expect(foo).to.have.been.calledTwice
+      style: primary
+      start: 0
+      end: 36

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledTwice_and_calledWith-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledTwice_and_calledWith-snapshot.yml
@@ -1,0 +1,29 @@
+id: sinon_to_vitest_expect_calledTwice_and_calledWith
+snapshots:
+  expect(foo).to.have.been.calledTwice.and.to.have.been.calledWith(x, y):
+    fixed: |-
+      expect(foo).toHaveBeenCalledTimes(2);
+      expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledTwice.and.to.have.been.calledWith(x, y)
+      style: primary
+      start: 0
+      end: 70
+  expect(foo).to.have.been.calledTwice.and.to.have.been.calledWithExactly(x, y):
+    fixed: |-
+      expect(foo).toHaveBeenCalledTimes(2);
+      expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledTwice.and.to.have.been.calledWithExactly(x, y)
+      style: primary
+      start: 0
+      end: 77
+  expect(foo).to.have.been.calledTwice.and.to.have.been.calledWithMatch(x, y):
+    fixed: |-
+      expect(foo).toHaveBeenCalledTimes(2);
+      expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledTwice.and.to.have.been.calledWithMatch(x, y)
+      style: primary
+      start: 0
+      end: 75

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledWith-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledWith-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_calledWith
+snapshots:
+  expect(foo).to.have.been.calledWith(x, y):
+    fixed: expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledWith(x, y)
+      style: primary
+      start: 0
+      end: 41
+  expect(foo).to.have.been.calledWithExactly(x, y):
+    fixed: expect(foo).toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).to.have.been.calledWithExactly(x, y)
+      style: primary
+      start: 0
+      end: 48

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledWithMatch-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_calledWithMatch-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_calledWithMatch
+snapshots:
+  expect(foo).to.have.been.calledWithMatch(bar):
+    fixed: expect(foo).toHaveBeenCalledWith(bar)
+    labels:
+    - source: expect(foo).to.have.been.calledWithMatch(bar)
+      style: primary
+      start: 0
+      end: 45
+  expect(foo).to.have.been.calledWithMatch(bar, baz):
+    fixed: expect(foo).toHaveBeenCalledWith(bar, baz)
+    labels:
+    - source: expect(foo).to.have.been.calledWithMatch(bar, baz)
+      style: primary
+      start: 0
+      end: 50

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_not_called-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_not_called-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_not_called
+snapshots:
+  expect(foo).not.to.have.been.called:
+    fixed: expect(foo).not.toHaveBeenCalled()
+    labels:
+    - source: expect(foo).not.to.have.been.called
+      style: primary
+      start: 0
+      end: 35
+  expect(foo).to.not.have.been.called:
+    fixed: expect(foo).not.toHaveBeenCalled()
+    labels:
+    - source: expect(foo).to.not.have.been.called
+      style: primary
+      start: 0
+      end: 35

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_not_calledWith-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_expect_not_calledWith-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_expect_not_calledWith
+snapshots:
+  expect(foo).not.to.have.been.calledWith(x, y):
+    fixed: expect(foo).not.toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).not.to.have.been.calledWith(x, y)
+      style: primary
+      start: 0
+      end: 45
+  expect(foo).not.to.have.been.calledWithExactly(x, y):
+    fixed: expect(foo).not.toHaveBeenCalledWith(x, y)
+    labels:
+    - source: expect(foo).not.to.have.been.calledWithExactly(x, y)
+      style: primary
+      start: 0
+      end: 52

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_match-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_match-snapshot.yml
@@ -1,0 +1,16 @@
+id: sinon_to_vitest_match
+snapshots:
+  expect(foo).to.equal(sinon.match(bar)):
+    fixed: expect(foo).to.equal(expect.objectContaining(bar))
+    labels:
+    - source: sinon.match(bar)
+      style: primary
+      start: 21
+      end: 37
+  sinon.match(foo):
+    fixed: expect.objectContaining(foo)
+    labels:
+    - source: sinon.match(foo)
+      style: primary
+      start: 0
+      end: 16

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_match_func-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_match_func-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_match_func
+snapshots:
+  sinon.match.func:
+    fixed: expect.any(Function)
+    labels:
+    - source: sinon.match.func
+      style: primary
+      start: 0
+      end: 16

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_resetHistory-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_resetHistory-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_resetHistory
+snapshots:
+  foo.resetHistory():
+    fixed: foo.mockClear()
+    labels:
+    - source: foo.resetHistory()
+      style: primary
+      start: 0
+      end: 18

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_spy-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_spy-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_spy
+snapshots:
+  sinon.spy():
+    fixed: vi.fn()
+    labels:
+    - source: sinon.spy()
+      style: primary
+      start: 0
+      end: 11

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_spy_method-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_spy_method-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_spy_method
+snapshots:
+  sinon.spy(obj, prop):
+    fixed: vi.spyOn(obj, prop)
+    labels:
+    - source: sinon.spy(obj, prop)
+      style: primary
+      start: 0
+      end: 20

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_spy_with_args-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_spy_with_args-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_spy_with_args
+snapshots:
+  sinon.spy(foo):
+    fixed: vi.fn(foo)
+    labels:
+    - source: sinon.spy(foo)
+      style: primary
+      start: 0
+      end: 14

--- a/test/sg/codemods/__snapshots__/sinon_to_vitest_stub_with_args-snapshot.yml
+++ b/test/sg/codemods/__snapshots__/sinon_to_vitest_stub_with_args-snapshot.yml
@@ -1,0 +1,9 @@
+id: sinon_to_vitest_stub_with_args
+snapshots:
+  sinon.stub(obj, prop):
+    fixed: vi.spyOn(obj, prop).mockImplementation(() => {})
+    labels:
+    - source: sinon.stub(obj, prop)
+      style: primary
+      start: 0
+      end: 21

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-callcount.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-callcount.yml
@@ -1,0 +1,6 @@
+id: sinon_to_vitest_expect_callCount
+valid:
+  - expect(foo).toHaveBeenCalledTimes(2)
+  - expect(foo).not.to.have.callCount(2)
+invalid:
+  - expect(foo).to.have.callCount(2)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-called.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-called.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_expect_called
+valid:
+  - expect(foo).toHaveBeenCalled()
+  - expect(foo).to.have.been.calledOnce
+  - expect(foo).not.to.have.been.called
+invalid:
+  - expect(foo).to.have.been.called

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledbefore.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledbefore.yml
@@ -1,0 +1,6 @@
+id: sinon_to_vitest_expect_calledBefore
+valid:
+  - expect(foo).toHaveBeenCalledBefore(bar)
+  - expect(foo).not.to.have.been.calledBefore(bar)
+invalid:
+  - expect(foo).to.have.been.calledBefore(bar)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledonce-and-calledwith.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledonce-and-calledwith.yml
@@ -1,0 +1,11 @@
+id: sinon_to_vitest_expect_calledOnce_and_calledWith
+valid:
+  - expect(foo).toHaveBeenCalledTimes(1)
+  - expect(foo).to.have.been.calledOnce
+  - expect(foo).to.have.been.calledWith(x, y)
+  - expect(foo).to.have.been.calledWithExactly(x, y)
+  - expect(foo).to.have.been.calledWithMatch(x, y)
+invalid:
+  - expect(foo).to.have.been.calledOnce.and.to.have.been.calledWith(x, y)
+  - expect(foo).to.have.been.calledOnce.and.to.have.been.calledWithExactly(x, y)
+  - expect(foo).to.have.been.calledOnce.and.to.have.been.calledWithMatch(x, y)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledonce.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledonce.yml
@@ -1,0 +1,8 @@
+id: sinon_to_vitest_expect_calledOnce
+valid:
+  - expect(foo).toHaveBeenCalledOnce()
+  - expect(foo).to.have.been.called
+  - expect(foo).not.to.have.been.calledOnce
+invalid:
+  - expect(foo).to.have.been.calledOnce
+  - expect(foo).to.be.calledOnce

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledthrice.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledthrice.yml
@@ -1,0 +1,8 @@
+id: sinon_to_vitest_expect_calledThrice
+valid:
+  - expect(foo).toHaveBeenCalledTimes(3)
+  - expect(foo).to.have.been.calledOnce
+  - expect(foo).not.to.have.been.calledThrice
+invalid:
+  - expect(foo).to.have.been.calledThrice
+  - expect(foo).to.be.calledThrice

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledtwice-and-calledwith.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledtwice-and-calledwith.yml
@@ -1,0 +1,11 @@
+id: sinon_to_vitest_expect_calledTwice_and_calledWith
+valid:
+  - expect(foo).toHaveBeenCalledTimes(2)
+  - expect(foo).to.have.been.calledTwice
+  - expect(foo).to.have.been.calledWith(x, y)
+  - expect(foo).to.have.been.calledWithExactly(x, y)
+  - expect(foo).to.have.been.calledWithMatch(x, y)
+invalid:
+  - expect(foo).to.have.been.calledTwice.and.to.have.been.calledWith(x, y)
+  - expect(foo).to.have.been.calledTwice.and.to.have.been.calledWithExactly(x, y)
+  - expect(foo).to.have.been.calledTwice.and.to.have.been.calledWithMatch(x, y)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledtwice.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledtwice.yml
@@ -1,0 +1,8 @@
+id: sinon_to_vitest_expect_calledTwice
+valid:
+  - expect(foo).toHaveBeenCalledTimes(2)
+  - expect(foo).to.have.been.calledOnce
+  - expect(foo).not.to.have.been.calledTwice
+invalid:
+  - expect(foo).to.have.been.calledTwice
+  - expect(foo).to.be.calledTwice

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledwith.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledwith.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_expect_calledWith
+valid:
+  - expect(foo).toHaveBeenCalledWith(x, y)
+  - expect(foo).not.to.have.been.calledWith(x, y)
+invalid:
+  - expect(foo).to.have.been.calledWith(x, y)
+  - expect(foo).to.have.been.calledWithExactly(x, y)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledwithmatch.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-calledwithmatch.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_expect_calledWithMatch
+valid:
+  - expect(foo).toHaveBeenCalledWith(bar)
+  - expect(foo).not.to.have.been.calledWithMatch(bar)
+invalid:
+  - expect(foo).to.have.been.calledWithMatch(bar)
+  - expect(foo).to.have.been.calledWithMatch(bar, baz)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-not-called.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-not-called.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_expect_not_called
+valid:
+  - expect(foo).not.toHaveBeenCalled()
+  - expect(foo).to.have.been.called
+invalid:
+  - expect(foo).to.not.have.been.called
+  - expect(foo).not.to.have.been.called

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-not-calledwith.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-expect-not-calledwith.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_expect_not_calledWith
+valid:
+  - expect(foo).not.toHaveBeenCalledWith(x, y)
+  - expect(foo).to.have.been.calledWith(x, y)
+invalid:
+  - expect(foo).not.to.have.been.calledWith(x, y)
+  - expect(foo).not.to.have.been.calledWithExactly(x, y)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-match-func.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-match-func.yml
@@ -1,0 +1,6 @@
+id: sinon_to_vitest_match_func
+valid:
+  - sinon.match.object
+  - expect.any(Function)
+invalid:
+  - sinon.match.func

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-match.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-match.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_match
+valid:
+  - expect.objectContaining(foo)
+  - sinon.match(foo, bar)
+invalid:
+  - sinon.match(foo)
+  - expect(foo).to.equal(sinon.match(bar))

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-resethistory.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-resethistory.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_resetHistory
+valid:
+  - foo.mockClear()
+  - foo.reset()
+  - foo.resetHistory(a, b)
+invalid:
+  - foo.resetHistory()

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-spy-method.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-spy-method.yml
@@ -1,0 +1,7 @@
+id: sinon_to_vitest_spy_method
+valid:
+  - sinon.spy()
+  - sinon.spy(fn)
+  - vi.spyOn(obj, prop)
+invalid:
+  - sinon.spy(obj, prop)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-spy-with-args.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-spy-with-args.yml
@@ -1,0 +1,6 @@
+id: sinon_to_vitest_spy_with_args
+valid:
+  - vi.fn()
+  - sinon.spy()
+invalid:
+  - sinon.spy(foo)

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-spy.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-spy.yml
@@ -1,0 +1,6 @@
+id: sinon_to_vitest_spy
+valid:
+  - vi.fn()
+  - sinon.spy(foo)
+invalid:
+  - sinon.spy()

--- a/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-stub-with-args.yml
+++ b/test/sg/codemods/sinon-to-vitest/sinon-to-vitest-stub-with-args.yml
@@ -1,0 +1,8 @@
+id: sinon_to_vitest_stub_with_args
+valid:
+  - vi.spyOn(obj, prop)
+  - vi.spyOn(obj, prop).mockImplementation(() => {})
+  - sinon.stub()
+  - sinon.spy()
+invalid:
+  - sinon.stub(obj, prop)


### PR DESCRIPTION
This is very far from a full codemod and will leave various errors in
some chained cases, but gets you a fair distance.

Converts between `expect(foo).to.have.been.called` style assertions
(sinon) to `expect(foo).toHaveBeenCalled()` (vitest).
